### PR TITLE
Creating more methods to person endpoint

### DIFF
--- a/Hanka.ApiDotNet6.Api/Controllers/PersonController.cs
+++ b/Hanka.ApiDotNet6.Api/Controllers/PersonController.cs
@@ -16,13 +16,35 @@ public class PersonController : ControllerBase
   }
 
   [HttpPost]
-  public async Task<ActionResult> Post([FromBody] PersonDTO personDTO)
+  public async Task<ActionResult> PostAsync([FromBody] PersonDTO personDTO)
   {
     var result = await _personService.CreateAsync(personDTO);
     if (result.IsSuccess)
       return Ok(result);
 
     return BadRequest(result);
+
+  }
+
+  [HttpGet]
+  public async Task<ActionResult<List<PersonDTO>>> GetAsync()
+  {
+    var result = await _personService.GetAsync();
+    if (result.IsSuccess)
+    return Ok(result);
+
+    return BadRequest(result);
+  }
+
+  [HttpGet]
+  [Route("{id}")]
+  public async Task<ActionResult> GetByIdAsync(int id)
+  {
+    var result = await _personService.GetAsyncById(id);
+    if (result.IsSuccess)
+      return Ok(result);
+
+      return BadRequest(result);
 
   }
 

--- a/Hanka.ApiDotNet6.Api/Program.cs
+++ b/Hanka.ApiDotNet6.Api/Program.cs
@@ -1,4 +1,5 @@
-﻿using Hanka.ApiDotNet6.Infra.IoC;
+﻿using System.Text.Json.Serialization;
+using Hanka.ApiDotNet6.Infra.IoC;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +11,9 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddService(builder.Configuration);
+builder.Services.AddMvc().AddJsonOptions(options => {
+    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+});
 
 var app = builder.Build();
 

--- a/Hanka.ApiDotNet6.Api/Properties/launchSettings.json
+++ b/Hanka.ApiDotNet6.Api/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7154;http://localhost:5051",
+      "applicationUrl": "http://localhost:7154;http://localhost:5051",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Hanka.ApiDotNet6.Api/appsettings.json
+++ b/Hanka.ApiDotNet6.Api/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=127.0.0.1;Port=5432;Database=hanka_database_api;User Id=postgres;Password=@Acce5511"
+    "DefaultConnection": "Server=127.0.0.1;Port=5432;Database=hanka_db;User Id=postgres;Password=@Acce5511"
   },
   "Logging": {
     "LogLevel": {

--- a/Hanka.ApiDotNet6.Application/Services/Interfaces/IPersonService.cs
+++ b/Hanka.ApiDotNet6.Application/Services/Interfaces/IPersonService.cs
@@ -5,4 +5,7 @@ namespace Hanka.ApiDotNet6.Application.Services.Interfaces;
 public interface IPersonService
 {
   Task<ResultService<PersonDTO>> CreateAsync(PersonDTO personDTO);
+  Task<ResultService<ICollection<PersonDTO>>> GetAsync();
+  Task<ResultService<PersonDTO>> GetAsyncById(int id);
+
 }

--- a/Hanka.ApiDotNet6.Application/Services/PersonService.cs
+++ b/Hanka.ApiDotNet6.Application/Services/PersonService.cs
@@ -34,4 +34,18 @@ public class PersonService : IPersonService
     return ResultService.OK<PersonDTO>(_mapper.Map<PersonDTO>(data));
 
   }
+
+  public async Task<ResultService<ICollection<PersonDTO>>> GetAsync()
+  {
+    var person= await _personRepository.GetPeopleAsync();
+    return ResultService.OK<ICollection<PersonDTO>>(_mapper.Map<ICollection<PersonDTO>>(person));
+  }
+
+  public async Task<ResultService<PersonDTO>> GetAsyncById(int id)
+  {
+    var person = await _personRepository.GetByIdAsync(id);
+    if (person == null)
+      return ResultService.Fail<PersonDTO>("Person not found");
+    return ResultService.OK(_mapper.Map<PersonDTO>(person));
+  }
 }


### PR DESCRIPTION
In this PR was created two new methods in the IPersonService

```csharp
  Task<ResultService<ICollection<PersonDTO>>> GetAsync();
  Task<ResultService<PersonDTO>> GetAsyncById(int id);
``` 
The first one is used to get all person via Async request passing a collecton in the same Scheme for `PersonDTO`.

This methods was implemented on the PersonService

```csharp
  public async Task<ResultService<ICollection<PersonDTO>>> GetAsync()
  {
    var person= await _personRepository.GetPeopleAsync();
    return ResultService.OK<ICollection<PersonDTO>>(_mapper.Map<ICollection<PersonDTO>>(person));
  }

  public async Task<ResultService<PersonDTO>> GetAsyncById(int id)
  {
    var person = await _personRepository.GetByIdAsync(id);
    if (person == null)
      return ResultService.Fail<PersonDTO>("Person not found");
    return ResultService.OK(_mapper.Map<PersonDTO>(person));
  }
``` 

Some other changes in other files was because i change my PC and i had to created a new DB for Hanka Api example, just the name was changed;

Some other good funcionality to get a better DX on Swagger/Docs:

This line on the `Program.cs` configuration remove the entire null fields on the objects request through Swagger, this a good option to get a better read;

```csharp
builder.Services.AddMvc().AddJsonOptions(options => {
    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
});
```